### PR TITLE
fix: adjust the mouse tracking to be based on the canvas

### DIFF
--- a/src/hooks/use-mouse-position.js
+++ b/src/hooks/use-mouse-position.js
@@ -1,17 +1,22 @@
 import { useState, useEffect } from 'react'
 
-const useMousePosition = () => {
+const useMousePosition = (canvas) => {
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 })
 
   useEffect(() => {
-    const setPosition = (event) =>
-      setMousePosition({ x: event.clientX, y: event.clientY })
-    window.addEventListener('mousemove', setPosition)
+    const setPosition = (event) => {
+      setMousePosition({ x: event.offsetX, y: event.offsetY })
+    }
+    if (canvas) {
+      canvas.addEventListener('mousemove', setPosition)
+    }
 
     return () => {
-      window.removeEventListener('mousemove', setPosition)
+      if (canvas) {
+        canvas.removeEventListener('mousemove', setPosition)
+      }
     }
-  }, [])
+  }, [canvas])
 
   return mousePosition
 }

--- a/src/robots/rive-bot.js
+++ b/src/robots/rive-bot.js
@@ -9,16 +9,17 @@ const STATE_MACHINE = 'State Machine 1'
 
 const RiveBot = () => {
   const prefersReducedMotion = usePrefersReducedMotion()
-  const mousePosition = useMousePosition()
 
   const [maxWidth, setMaxWidth] = useState()
   const [maxHeight, setMaxHeight] = useState()
 
-  const { RiveComponent, rive } = useRive({
+  const { RiveComponent, rive, canvas } = useRive({
     src: Bot,
     stateMachines: STATE_MACHINE,
     autoplay: true,
   })
+
+  const mousePosition = useMousePosition(canvas)
 
   const isLimitedInput = useStateMachineInput(rive, STATE_MACHINE, 'isLimited')
   const xAxisInput = useStateMachineInput(rive, STATE_MACHINE, 'xAxis', 0)
@@ -26,13 +27,12 @@ const RiveBot = () => {
   const isHoverInput = useStateMachineInput(rive, STATE_MACHINE, 'isHover')
 
   useEffect(() => {
-    const body = document.querySelector('body')
-    if (body) {
-      const bodyRect = body.getBoundingClientRect()
-      setMaxWidth(bodyRect.right)
-      setMaxHeight(bodyRect.bottom)
+    if (canvas) {
+      const canvasRect = canvas.getBoundingClientRect()
+      setMaxWidth(canvasRect.right)
+      setMaxHeight(canvasRect.bottom)
     }
-  }, [])
+  }, [canvas])
 
   useEffect(() => {
     if (rive && isLimitedInput) {


### PR DESCRIPTION
Talked with JC - sounds like the intent is to track mouse cursor on hover of the canvas rather than the general viewport as bounds. We get the canvas element from the `useRive` hook so just passing that along where needed