### PR TITLE
fix: revise canvas dimensions logic

### DIFF
--- a/src/robots/rive-bot.js
+++ b/src/robots/rive-bot.js
@@ -27,10 +27,21 @@ const RiveBot = () => {
   const isHoverInput = useStateMachineInput(rive, STATE_MACHINE, 'isHover')
 
   useEffect(() => {
+    let observer
     if (canvas) {
-      const canvasRect = canvas.getBoundingClientRect()
-      setMaxWidth(canvasRect.right)
-      setMaxHeight(canvasRect.bottom)
+      const setCanvasDimensions = () => {
+        const canvasRect = canvas.getBoundingClientRect()
+        setMaxWidth(canvasRect.width)
+        setMaxHeight(canvasRect.height)
+      }
+
+      observer = new ResizeObserver(setCanvasDimensions).observe(canvas)
+    }
+
+    return () => {
+      if (canvas && observer) {
+        observer.disconnect()
+      }
     }
   }, [canvas])
 


### PR DESCRIPTION
The y-axis tracking wasn't really taking place - found out that the `bottom` value here was really large for setting the `maxHeight` because it's the distance from the top of the page to the bottom of that canvas element (which is big). Using the `width` and `height` properties, especially because it could change should make more sense here.